### PR TITLE
5GMS - Media Stream Handler: QoE metrics collection feature

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="Embedded JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdk 29
         targetSdk 32
         versionCode 1
-        versionName "1.0.1"
+        versionName "1.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -37,7 +37,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.fivegmag'
             artifactId = 'a5gmsmediastreamhandler'
-            version = '1.0.1'
+            version = '1.1.0'
             afterEvaluate {
                 from components.release
             }
@@ -67,7 +67,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1'
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.fivegmag:a5gmscommonlibrary:1.0.1'
+    implementation 'com.fivegmag:a5gmscommonlibrary:1.1.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,7 +61,8 @@ dependencies {
     implementation "androidx.media3:media3-exoplayer-dash:1.0.2"
     implementation "androidx.media3:media3-exoplayer-hls:1.0.2"
     implementation "androidx.media3:media3-ui:1.0.2"
-    implementation 'org.simpleframework:simple-xml:2.7.1'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.0'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.5'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation "androidx.media3:media3-exoplayer-dash:1.0.2"
     implementation "androidx.media3:media3-exoplayer-hls:1.0.2"
     implementation "androidx.media3:media3-ui:1.0.2"
+    implementation 'org.simpleframework:simple-xml:2.7.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,17 +57,18 @@ publishing {
 }
 
 dependencies {
-    implementation "androidx.media3:media3-exoplayer:1.0.2"
-    implementation "androidx.media3:media3-exoplayer-dash:1.0.2"
-    implementation "androidx.media3:media3-exoplayer-hls:1.0.2"
-    implementation "androidx.media3:media3-ui:1.0.2"
+    implementation "androidx.media3:media3-exoplayer:1.1.0"
+    implementation "androidx.media3:media3-exoplayer-dash:1.1.0"
+    implementation "androidx.media3:media3-exoplayer-hls:1.1.0"
+    implementation "androidx.media3:media3-ui:1.1.0"
     implementation 'com.fasterxml.jackson.core:jackson-core:2.15.0'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.5'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.0'
+    implementation 'javax.xml.stream:stax-api:1.0-2'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1'
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.fivegmag:a5gmscommonlibrary:1.0.1'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -28,6 +28,7 @@ import androidx.media3.ui.PlayerView
 import com.fivegmag.a5gmscommonlibrary.helpers.MetricReportingSchemes
 import com.fivegmag.a5gmscommonlibrary.helpers.PlayerStates
 import com.fivegmag.a5gmscommonlibrary.helpers.StatusInformation
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import com.fivegmag.a5gmsmediastreamhandler.helpers.mapStateToConstant
@@ -139,6 +140,10 @@ class ExoPlayerAdapter() {
         return playerListener.getHttpList()
     }
 
+    fun getBufferLevel() : BufferLevel {
+        return playerListener.getBufferLevel()
+    }
+
     fun resetListenerValues() {
         playerListener.reset()
     }
@@ -147,7 +152,7 @@ class ExoPlayerAdapter() {
         return bandwidthMeter.bitrateEstimate
     }
 
-    fun getBufferLength(): Long {
+    private fun getBufferLength(): Long {
         return playerInstance.totalBufferedDuration
     }
 

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -29,11 +29,8 @@ import com.fivegmag.a5gmscommonlibrary.helpers.MetricReportingSchemes
 import com.fivegmag.a5gmscommonlibrary.helpers.PlayerStates
 import com.fivegmag.a5gmscommonlibrary.helpers.StatusInformation
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
-import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsReport
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import com.fivegmag.a5gmsmediastreamhandler.helpers.mapStateToConstant
-import com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP.QoEMetricsExoPlayer
-import java.lang.Exception
 
 
 @UnstableApi
@@ -124,6 +121,10 @@ class ExoPlayerAdapter() {
 
     fun getPlayerInstance(): ExoPlayer {
         return playerInstance
+    }
+
+    fun getCurrentManifestUrl() : String {
+        return playerInstance.currentMediaItem?.localConfiguration?.uri.toString()
     }
 
     fun getPlaybackState(): Int {

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -31,6 +31,7 @@ import com.fivegmag.a5gmscommonlibrary.helpers.PlayerStates
 import com.fivegmag.a5gmscommonlibrary.helpers.StatusInformation
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.MpdInformation
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import com.fivegmag.a5gmsmediastreamhandler.helpers.mapStateToConstant
 
@@ -156,6 +157,10 @@ class ExoPlayerAdapter() {
 
     fun getBufferLevel(): BufferLevel {
         return playerListener.getBufferLevel()
+    }
+
+    fun getMpdInformation(): ArrayList<MpdInformation> {
+        return playerListener.getMpdInformation()
     }
 
     fun resetListenerValues() {

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -28,7 +28,9 @@ import androidx.media3.ui.PlayerView
 import com.fivegmag.a5gmscommonlibrary.helpers.MetricReportingSchemes
 import com.fivegmag.a5gmscommonlibrary.helpers.PlayerStates
 import com.fivegmag.a5gmscommonlibrary.helpers.StatusInformation
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsReport
 import com.fivegmag.a5gmsmediastreamhandler.helpers.mapStateToConstant
+import com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP.QoEMetricsExoPlayer
 
 
 @UnstableApi
@@ -43,7 +45,7 @@ class ExoPlayerAdapter() {
     private lateinit var mediaSessionHandlerAdapter: MediaSessionHandlerAdapter
     private lateinit var playbackStatsListener: PlaybackStatsListener
     private var supportedMetricsSchemes =
-        listOf(MetricReportingSchemes.FIVE_G_MAG_EXOPLAYER_COMBINED_PLAYBACK_STATS)
+        listOf(MetricReportingSchemes.FIVE_G_MAG_EXOPLAYER_COMBINED_PLAYBACK_STATS, MetricReportingSchemes.THREE_GPP_DASH_METRIC_REPORTING)
 
     var httpDataSourceFactory: HttpDataSource.Factory =
         DefaultHttpDataSource.Factory().setAllowCrossProtocolRedirects(true)
@@ -125,7 +127,7 @@ class ExoPlayerAdapter() {
         return bandwidthMeter.bitrateEstimate
     }
 
-    private fun getBufferLength(): Long {
+    fun getBufferLength(): Long {
         return playerInstance.totalBufferedDuration
     }
 

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -28,10 +28,12 @@ import androidx.media3.ui.PlayerView
 import com.fivegmag.a5gmscommonlibrary.helpers.MetricReportingSchemes
 import com.fivegmag.a5gmscommonlibrary.helpers.PlayerStates
 import com.fivegmag.a5gmscommonlibrary.helpers.StatusInformation
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsReport
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import com.fivegmag.a5gmsmediastreamhandler.helpers.mapStateToConstant
 import com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP.QoEMetricsExoPlayer
+import java.lang.Exception
 
 
 @UnstableApi
@@ -46,7 +48,10 @@ class ExoPlayerAdapter() {
     private lateinit var mediaSessionHandlerAdapter: MediaSessionHandlerAdapter
     private lateinit var playbackStatsListener: PlaybackStatsListener
     private var supportedMetricsSchemes =
-        listOf(MetricReportingSchemes.FIVE_G_MAG_EXOPLAYER_COMBINED_PLAYBACK_STATS, MetricReportingSchemes.THREE_GPP_DASH_METRIC_REPORTING)
+        listOf(
+            MetricReportingSchemes.FIVE_G_MAG_EXOPLAYER_COMBINED_PLAYBACK_STATS,
+            MetricReportingSchemes.THREE_GPP_DASH_METRIC_REPORTING
+        )
 
     var httpDataSourceFactory: HttpDataSource.Factory =
         DefaultHttpDataSource.Factory().setAllowCrossProtocolRedirects(true)
@@ -125,8 +130,16 @@ class ExoPlayerAdapter() {
         return playerInstance.playbackState
     }
 
-    fun getRepresentationSwitchList() : RepresentationSwitchList {
+    fun getRepresentationSwitchList(): RepresentationSwitchList {
         return playerListener.getRepresentationSwitchList()
+    }
+
+    fun getHttpList(): HttpList {
+        return playerListener.getHttpList()
+    }
+
+    fun resetListenerValues() {
+        playerListener.reset()
     }
 
     private fun getAverageThroughput(): Long {

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -87,7 +87,9 @@ class ExoPlayerAdapter() {
     }
 
     fun attach(url: String) {
-        playerListener.reset()
+        mediaSessionHandlerAdapter.sendFinalPlaybackMetricsMessage()
+        mediaSessionHandlerAdapter.resetForNewStreamingSession()
+        resetListenerValues()
         val mediaItem: MediaItem = MediaItem.fromUri(url)
         playerInstance.setMediaItem(mediaItem)
         activeMediaItem = mediaItem

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -137,6 +137,10 @@ class ExoPlayerAdapter() {
         return playbackStatsListener.combinedPlaybackStats
     }
 
+    fun getPlaybackStats(): PlaybackStats? {
+        return playbackStatsListener.playbackStats
+    }
+
     fun isMetricsSchemeSupported(metricsScheme: String): Boolean {
         Log.d(TAG, "Checking if metrics scheme $metricsScheme is supported")
         return supportedMetricsSchemes.contains(metricsScheme)

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -42,7 +42,7 @@ class ExoPlayerAdapter() {
     private lateinit var bandwidthMeter: DefaultBandwidthMeter
     private lateinit var mediaSessionHandlerAdapter: MediaSessionHandlerAdapter
     private lateinit var playbackStatsListener: PlaybackStatsListener
-    private var supportedMetricSchemes =
+    private var supportedMetricsSchemes =
         listOf(MetricReportingSchemes.FIVE_G_MAG_EXOPLAYER_COMBINED_PLAYBACK_STATS)
 
     var httpDataSourceFactory: HttpDataSource.Factory =
@@ -137,9 +137,9 @@ class ExoPlayerAdapter() {
         return playbackStatsListener.combinedPlaybackStats
     }
 
-    fun isMetricSchemeSupported(metricScheme: String): Boolean {
-        Log.d(TAG, "Checking if metric scheme $metricScheme is supported")
-        return supportedMetricSchemes.contains(metricScheme)
+    fun isMetricsSchemeSupported(metricsScheme: String): Boolean {
+        Log.d(TAG, "Checking if metrics scheme $metricsScheme is supported")
+        return supportedMetricsSchemes.contains(metricsScheme)
     }
 
     fun getStatusInformation(status: String): Any? {

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -29,6 +29,7 @@ import com.fivegmag.a5gmscommonlibrary.helpers.MetricReportingSchemes
 import com.fivegmag.a5gmscommonlibrary.helpers.PlayerStates
 import com.fivegmag.a5gmscommonlibrary.helpers.StatusInformation
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsReport
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import com.fivegmag.a5gmsmediastreamhandler.helpers.mapStateToConstant
 import com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP.QoEMetricsExoPlayer
 
@@ -40,7 +41,7 @@ class ExoPlayerAdapter() {
     private lateinit var playerInstance: ExoPlayer
     private lateinit var playerView: PlayerView
     private lateinit var activeMediaItem: MediaItem
-    private lateinit var playerListener: AnalyticsListener
+    private lateinit var playerListener: ExoPlayerListener
     private lateinit var bandwidthMeter: DefaultBandwidthMeter
     private lateinit var mediaSessionHandlerAdapter: MediaSessionHandlerAdapter
     private lateinit var playbackStatsListener: PlaybackStatsListener
@@ -82,6 +83,7 @@ class ExoPlayerAdapter() {
     }
 
     fun attach(url: String) {
+        playerListener.reset()
         val mediaItem: MediaItem = MediaItem.fromUri(url)
         playerInstance.setMediaItem(mediaItem)
         activeMediaItem = mediaItem
@@ -121,6 +123,10 @@ class ExoPlayerAdapter() {
 
     fun getPlaybackState(): Int {
         return playerInstance.playbackState
+    }
+
+    fun getRepresentationSwitchList() : RepresentationSwitchList {
+        return playerListener.getRepresentationSwitchList()
     }
 
     private fun getAverageThroughput(): Long {

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -21,6 +21,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.analytics.PlaybackStats
 import androidx.media3.exoplayer.analytics.PlaybackStatsListener
+import androidx.media3.exoplayer.dash.manifest.DashManifest
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.exoplayer.util.EventLogger
@@ -124,8 +125,19 @@ class ExoPlayerAdapter() {
         return playerInstance
     }
 
-    fun getCurrentManifestUrl() : String {
+    fun getCurrentManifestUrl(): String {
         return playerInstance.currentMediaItem?.localConfiguration?.uri.toString()
+    }
+
+    fun getCurrentPeriodId(): String {
+        val dashManifest = playerInstance.currentManifest as DashManifest
+        val periodId = dashManifest.getPeriod(playerInstance.currentPeriodIndex).id
+
+        if (periodId != null) {
+            return periodId
+        }
+
+        return ""
     }
 
     fun getPlaybackState(): Int {
@@ -140,7 +152,7 @@ class ExoPlayerAdapter() {
         return playerListener.getHttpList()
     }
 
-    fun getBufferLevel() : BufferLevel {
+    fun getBufferLevel(): BufferLevel {
         return playerListener.getBufferLevel()
     }
 

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
@@ -27,6 +27,8 @@ import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevelEntr
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpListEntry
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpListEntryType
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.MpdInfo
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.MpdInformation
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitch
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.Trace
@@ -47,6 +49,7 @@ class ExoPlayerListener(
     )
     private val httpList: HttpList = HttpList(ArrayList<HttpListEntry>())
     private val bufferLevel: BufferLevel = BufferLevel(ArrayList<BufferLevelEntry>())
+    private val mpdInformation: ArrayList<MpdInformation> = ArrayList()
     private val utils: Utils = Utils()
 
     override fun onPlaybackStateChanged(
@@ -93,6 +96,33 @@ class ExoPlayerListener(
         val representationSwitch = to?.let { RepresentationSwitch(t, mt, it) }
         if (representationSwitch != null) {
             representationSwitchList.entries.add(representationSwitch)
+            addMpdInformation(mediaLoadData)
+        }
+    }
+
+    private fun addMpdInformation(mediaLoadData: MediaLoadData) {
+        val format = mediaLoadData.trackFormat
+        if (format != null) {
+            val representationId = mediaLoadData.trackFormat!!.id
+            val codecs = mediaLoadData.trackFormat!!.codecs
+            val bandwidth = mediaLoadData.trackFormat!!.peakBitrate
+            val mimeType = mediaLoadData.trackFormat!!.containerMimeType
+            val frameRate = mediaLoadData.trackFormat!!.frameRate
+            val width = mediaLoadData.trackFormat!!.width
+            val height = mediaLoadData.trackFormat!!.height
+            val mpdInfo = MpdInfo(codecs, bandwidth, mimeType)
+
+            if (frameRate > 0) {
+                mpdInfo.frameRate = frameRate.toDouble()
+            }
+            if (width > 0) {
+                mpdInfo.width = width
+            }
+
+            if (height > 0) {
+                mpdInfo.height = height
+            }
+            mpdInformation.add(MpdInformation(representationId, null, mpdInfo))
         }
     }
 
@@ -113,6 +143,10 @@ class ExoPlayerListener(
 
     fun getBufferLevel(): BufferLevel {
         return bufferLevel
+    }
+
+    fun getMpdInformation(): ArrayList<MpdInformation> {
+        return mpdInformation
     }
 
     override fun onLoadCompleted(
@@ -176,6 +210,7 @@ class ExoPlayerListener(
         representationSwitchList.entries.clear()
         httpList.entries.clear()
         bufferLevel.entries.clear()
+        mpdInformation.clear()
     }
 
 }

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
@@ -16,25 +16,35 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
 import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.source.MediaLoadData
 
 import com.fivegmag.a5gmsmediastreamhandler.helpers.mapStateToConstant
 import com.fivegmag.a5gmscommonlibrary.helpers.PlayerStates
+import com.fivegmag.a5gmscommonlibrary.helpers.Utils
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitch
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 
 // See https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/Player.Listener.html for possible events
-@UnstableApi class ExoPlayerListener(
+@UnstableApi
+class ExoPlayerListener(
     private val mediaSessionHandlerAdapter: MediaSessionHandlerAdapter,
     private val playerInstance: ExoPlayer,
-    private val playerView: PlayerView
+    private val playerView: PlayerView,
+    private val representationSwitchList: RepresentationSwitchList = RepresentationSwitchList(
+        ArrayList<RepresentationSwitch>()
+    )
 ) :
     AnalyticsListener {
+
+    private val utils: Utils = Utils()
 
     override fun onPlaybackStateChanged(
         eventTime: AnalyticsListener.EventTime,
         playbackState: Int
     ) {
-        val state : String = mapStateToConstant(playbackState)
+        val state: String = mapStateToConstant(playbackState)
 
-        playerView.keepScreenOn = !(state == PlayerStates.IDLE ||state == PlayerStates.ENDED)
+        playerView.keepScreenOn = !(state == PlayerStates.IDLE || state == PlayerStates.ENDED)
         mediaSessionHandlerAdapter.updatePlaybackState(state)
     }
 
@@ -52,6 +62,27 @@ import com.fivegmag.a5gmscommonlibrary.helpers.PlayerStates
 
     override fun onPlayerError(eventTime: AnalyticsListener.EventTime, error: PlaybackException) {
         Log.d("ExoPlayer", "Error")
+    }
+
+    override fun onDownstreamFormatChanged(
+        eventTime: AnalyticsListener.EventTime,
+        mediaLoadData: MediaLoadData
+    ) {
+        val t: Long = utils.getCurrentTimestamp()
+        val mt: Long = playerInstance.contentPosition
+        val to: String? = mediaLoadData.trackFormat?.id
+        val representationSwitch = to?.let { RepresentationSwitch(t, mt, it) }
+        if (representationSwitch != null) {
+            representationSwitchList.entries.add(representationSwitch)
+        }
+    }
+
+    fun getRepresentationSwitchList(): RepresentationSwitchList {
+        return representationSwitchList
+    }
+
+    fun reset() {
+        representationSwitchList.entries.clear()
     }
 
 }

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
@@ -121,7 +121,7 @@ class ExoPlayerListener(
     }
 
     private fun addHttpListEntry(mediaLoadData: MediaLoadData, loadEventInfo: LoadEventInfo) {
-        val tcpId = -1
+        val tcpId = null
         val type = getRequestType(mediaLoadData)
         val url = loadEventInfo.uri.toString()
         val actualUrl = loadEventInfo.uri.toString()

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
@@ -84,7 +84,7 @@ class ExoPlayerListener(
         eventTime: AnalyticsListener.EventTime,
         mediaLoadData: MediaLoadData
     ) {
-        val t: Long = utils.getCurrentTimestamp()
+        val t: String = utils.getCurrentXsDateTime()
         val mt: Long = playerInstance.contentPosition
         val to: String? = mediaLoadData.trackFormat?.id
         val representationSwitch = to?.let { RepresentationSwitch(t, mt, it) }
@@ -95,7 +95,7 @@ class ExoPlayerListener(
 
     private fun addBufferLevelEntry() {
         val level: Int = playerInstance.totalBufferedDuration.toInt()
-        val time: Long = utils.getCurrentTimestamp()
+        val time: String = utils.getCurrentXsDateTime()
         val entry = BufferLevelEntry(time, level)
         bufferLevel.entries.add(entry)
     }
@@ -127,8 +127,8 @@ class ExoPlayerListener(
         val url = loadEventInfo.uri.toString()
         val actualUrl = loadEventInfo.uri.toString()
         val range = ""
-        val tRequest = utils.getCurrentTimestamp() - loadEventInfo.loadDurationMs
-        val tResponse = utils.getCurrentTimestamp() - loadEventInfo.loadDurationMs
+        val tRequest = utils.convertTimestampToXsDateTime(utils.getCurrentTimestamp() - loadEventInfo.loadDurationMs)
+        val tResponse = utils.convertTimestampToXsDateTime(utils.getCurrentTimestamp() - loadEventInfo.loadDurationMs)
         val responseCode = 200
         val interval = loadEventInfo.loadDurationMs.toInt()
         val bytes = loadEventInfo.bytesLoaded.toInt()

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
@@ -59,6 +59,10 @@ class ExoPlayerListener(
             addBufferLevelEntry()
         }
 
+        if (state == PlayerStates.ENDED) {
+            mediaSessionHandlerAdapter.sendFinalPlaybackMetricsMessage()
+        }
+
         playerView.keepScreenOn = !(state == PlayerStates.IDLE || state == PlayerStates.ENDED)
         mediaSessionHandlerAdapter.updatePlaybackState(state)
     }
@@ -126,8 +130,10 @@ class ExoPlayerListener(
         val url = loadEventInfo.uri.toString()
         val actualUrl = loadEventInfo.uri.toString()
         val range = ""
-        val tRequest = utils.convertTimestampToXsDateTime(utils.getCurrentTimestamp() - loadEventInfo.loadDurationMs)
-        val tResponse = utils.convertTimestampToXsDateTime(utils.getCurrentTimestamp() - loadEventInfo.loadDurationMs)
+        val tRequest =
+            utils.convertTimestampToXsDateTime(utils.getCurrentTimestamp() - loadEventInfo.loadDurationMs)
+        val tResponse =
+            utils.convertTimestampToXsDateTime(utils.getCurrentTimestamp() - loadEventInfo.loadDurationMs)
         val responseCode = 200
         val interval = loadEventInfo.loadDurationMs.toInt()
         val bytes = loadEventInfo.bytesLoaded.toInt()

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
@@ -31,8 +31,7 @@ import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationS
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.Trace
 
-// See https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/Player.Listener.html for possible events
-
+// See https://developer.android.com/reference/androidx/media3/exoplayer/analytics/AnalyticsListener
 const val TAG = "ExoPlayerListener"
 
 @UnstableApi
@@ -85,7 +84,7 @@ class ExoPlayerListener(
         mediaLoadData: MediaLoadData
     ) {
         val t: String = utils.getCurrentXsDateTime()
-        val mt: Long = playerInstance.contentPosition
+        val mt: String? = utils.millisecondsToISO8601(playerInstance.currentPosition)
         val to: String? = mediaLoadData.trackFormat?.id
         val representationSwitch = to?.let { RepresentationSwitch(t, mt, it) }
         if (representationSwitch != null) {

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
@@ -12,24 +12,29 @@ package com.fivegmag.a5gmsmediastreamhandler
 import android.util.Log
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
 
 import com.fivegmag.a5gmsmediastreamhandler.helpers.mapStateToConstant
 import com.fivegmag.a5gmscommonlibrary.helpers.PlayerStates
 
 // See https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/Player.Listener.html for possible events
-class ExoPlayerListener(
+@UnstableApi class ExoPlayerListener(
     private val mediaSessionHandlerAdapter: MediaSessionHandlerAdapter,
     private val playerInstance: ExoPlayer
 ) :
-    Player.Listener {
+    AnalyticsListener {
 
-    override fun onPlaybackStateChanged(playbackState: Int) {
+    override fun onPlaybackStateChanged(
+        eventTime: AnalyticsListener.EventTime,
+        playbackState: Int
+    ) {
         val state : String = mapStateToConstant(playbackState)
         mediaSessionHandlerAdapter.updatePlaybackState(state)
     }
 
-    override fun onIsPlayingChanged(isPlaying: Boolean) {
+    override fun onIsPlayingChanged(eventTime: AnalyticsListener.EventTime, isPlaying: Boolean) {
         var state: String? = null
         if (isPlaying) {
             state = PlayerStates.PLAYING
@@ -41,7 +46,7 @@ class ExoPlayerListener(
         }
     }
 
-    override fun onPlayerError(error: PlaybackException) {
+    override fun onPlayerError(eventTime: AnalyticsListener.EventTime, error: PlaybackException) {
         Log.d("ExoPlayer", "Error")
     }
 

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/MediaSessionHandlerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/MediaSessionHandlerAdapter.kt
@@ -24,6 +24,7 @@ import com.fivegmag.a5gmscommonlibrary.helpers.MetricReportingSchemes
 import com.fivegmag.a5gmscommonlibrary.helpers.SessionHandlerMessageTypes
 import com.fivegmag.a5gmscommonlibrary.models.*
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.PlaybackMetricsRequest
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.PlaybackMetricsResponse
 import com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP.QoEMetricsExoPlayer
 import java.util.LinkedList
 
@@ -157,7 +158,10 @@ class MediaSessionHandlerAdapter() {
             )
 
             val responseBundle = Bundle()
-            responseBundle.putString("qoeMetricsReport", qoeMetricsReport)
+            val playbackMetricsResponse = PlaybackMetricsResponse(qoeMetricsReport,
+                playbackMetricsRequest?.metricReportingConfigurationId
+            )
+            responseBundle.putParcelable("playbackMetricsResponse", playbackMetricsResponse)
             msgResponse.data = responseBundle
             responseMessenger.send(msgResponse)
         }
@@ -307,7 +311,8 @@ class MediaSessionHandlerAdapter() {
             )
 
             val bundle = Bundle()
-            bundle.putString("qoeMetricsReport", qoeMetricsReport)
+            val playbackMetricsResponse = PlaybackMetricsResponse(qoeMetricsReport, playbackMetricsRequest.metricReportingConfigurationId)
+            bundle.putParcelable("playbackMetricsResponse", playbackMetricsResponse)
             msg.data = bundle
             msg.replyTo = mMessenger;
             try {

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/MediaSessionHandlerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/MediaSessionHandlerAdapter.kt
@@ -23,6 +23,7 @@ import com.fivegmag.a5gmscommonlibrary.helpers.ContentTypes
 import com.fivegmag.a5gmscommonlibrary.helpers.MetricReportingSchemes
 
 import com.fivegmag.a5gmscommonlibrary.helpers.SessionHandlerMessageTypes
+import com.fivegmag.a5gmscommonlibrary.helpers.Utils
 import com.fivegmag.a5gmscommonlibrary.models.*
 import com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP.QoEMetricsExoPlayer
 
@@ -38,8 +39,6 @@ class MediaSessionHandlerAdapter() {
     private var bound: Boolean = false
 
     private lateinit var exoPlayerAdapter: ExoPlayerAdapter
-
-    private lateinit var exoPlayerListener: ExoPlayerListener
 
     private lateinit var serviceConnectedCallbackFunction: () -> Unit
 
@@ -139,6 +138,7 @@ class MediaSessionHandlerAdapter() {
             Log.d(TAG, "Media Session Handler requested playback stats for scheme $scheme")
             if (scheme == MetricReportingSchemes.THREE_GPP_DASH_METRIC_REPORTING) {
                 qoeMetricsReport = qoEMetricsExoPlayer.getQoeMetricsReport()
+                exoPlayerAdapter.resetListenerValues()
             }
 
             val responseMessenger: Messenger = msg.replyTo
@@ -286,20 +286,6 @@ class MediaSessionHandlerAdapter() {
         val msg: Message = Message.obtain(null, SessionHandlerMessageTypes.STATUS_MESSAGE)
         val bundle = Bundle()
         bundle.putString("playbackState", state)
-        msg.data = bundle
-        try {
-            mService?.send(msg)
-        } catch (e: RemoteException) {
-            e.printStackTrace()
-        }
-    }
-
-    fun reportMetrics() {
-        if (!bound) return
-        // Create and send a message to the service, using a supported 'what' value
-        val msg: Message = Message.obtain(null, SessionHandlerMessageTypes.METRIC_REPORTING_MESSAGE)
-        val bundle = Bundle()
-        bundle.putString("metricData", "")
         msg.data = bundle
         try {
             mService?.send(msg)

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/MediaSessionHandlerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/MediaSessionHandlerAdapter.kt
@@ -39,6 +39,8 @@ class MediaSessionHandlerAdapter() {
 
     private lateinit var exoPlayerAdapter: ExoPlayerAdapter
 
+    private lateinit var exoPlayerListener: ExoPlayerListener
+
     private lateinit var serviceConnectedCallbackFunction: () -> Unit
 
     private lateinit var qoEMetricsExoPlayer: QoEMetricsExoPlayer

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/MediaSessionHandlerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/MediaSessionHandlerAdapter.kt
@@ -73,13 +73,13 @@ class MediaSessionHandlerAdapter() {
 
         private fun handlePlaybackMetricsCapabilitiesMessage(msg: Message) {
             val bundle: Bundle = msg.data
-            val schemes: ArrayList<String>? = bundle.getStringArrayList("metricSchemes")
+            val schemes: ArrayList<String>? = bundle.getStringArrayList("metricsSchemes")
             val results: ArrayList<SchemeSupport> = ArrayList()
 
             if (schemes != null) {
                 for (scheme in schemes) {
                     Log.d(TAG, "Scheme $scheme")
-                    val supported = exoPlayerAdapter.isMetricSchemeSupported(scheme)
+                    val supported = exoPlayerAdapter.isMetricsSchemeSupported(scheme)
                     Log.d(TAG, "$scheme is supported:")
                     results.add(SchemeSupport(scheme, supported))
                 }

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/3GPPDash.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/3GPPDash.kt
@@ -1,6 +1,0 @@
-package com.fivegmag.a5gmsmediastreamhandler.qoeMetrics
-
-interface `3GPPDash` {
-
-
-}

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/3GPPDash.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/3GPPDash.kt
@@ -1,0 +1,6 @@
+package com.fivegmag.a5gmsmediastreamhandler.qoeMetrics
+
+interface `3GPPDash` {
+
+
+}

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
@@ -1,13 +1,11 @@
 package com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP
 
-import android.util.Log
 import androidx.media3.common.util.UnstableApi
 import com.fivegmag.a5gmscommonlibrary.helpers.Utils
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.AvgThroughput
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevelEntry
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
-import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsReport
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import com.fivegmag.a5gmsmediastreamhandler.ExoPlayerAdapter
 import org.simpleframework.xml.core.Persister
@@ -49,16 +47,14 @@ class QoEMetricsExoPlayer(
     }
 
 
-    private fun serializeToXml(qoeMetricsReport: QoeMetricsReport): String {
+    fun serializeQoEMetricToXml(input: HttpList): String {
         val serializer = Persister()
         val stringWriter = StringWriter()
 
-        serializer.write(qoeMetricsReport, stringWriter)
+        serializer.write(input, stringWriter)
 
-        val serializedData = stringWriter.toString()
-
-        //return serializedData
-        return cleanupXml(serializedData)
+        val metricString = stringWriter.toString()
+        return "<QoeMetric>$metricString</QoeMetric>"
     }
 
     fun cleanupXml(xmlString: String): String {
@@ -79,6 +75,7 @@ class QoEMetricsExoPlayer(
                     if (xpp.name != "object") {
                         serializer.startTag(xpp.namespace, xpp.name)
 
+                        /*
                         // Copy attributes except "class" and those with value -1
                         for (i in 0 until xpp.attributeCount) {
                             val attributeName = xpp.getAttributeName(i)
@@ -87,6 +84,7 @@ class QoEMetricsExoPlayer(
                                 serializer.attribute("", attributeName, attributeValue)
                             }
                         }
+                        */
 
                     }
                 }
@@ -118,24 +116,22 @@ class QoEMetricsExoPlayer(
     }
 
     fun getQoeMetricsReport(): String {
-        val metricsList = ArrayList<Any>()
+        val metricsList = ArrayList<String>()
         val bufferLevel = getBufferLevel()
         val representationSwitchList = getRepresentationSwitchList()
         val httpList = getHttpList()
 
         if (bufferLevel.entries.size > 0) {
-            metricsList.add(bufferLevel)
+           // metricsList.add(serializeQoEMetricToXml(bufferLevel))
         }
         if (representationSwitchList.entries.size > 0) {
-            metricsList.add(representationSwitchList)
+            //metricsList.add(serializeQoEMetricToXml(representationSwitchList))
         }
         if (httpList.entries.size > 0) {
-            metricsList.add(httpList)
+            metricsList.add(serializeQoEMetricToXml(httpList))
         }
 
-        val qoeMetricsReport = QoeMetricsReport(metricsList)
-
-        return serializeToXml(qoeMetricsReport)
+        return java.lang.String.join(" ", metricsList)
     }
 
 

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
@@ -1,3 +1,12 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
 package com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP
 
 import androidx.media3.common.util.UnstableApi
@@ -6,7 +15,6 @@ import com.fivegmag.a5gmscommonlibrary.helpers.Utils
 import com.fivegmag.a5gmscommonlibrary.helpers.XmlSchemaStrings.THREE_GPP_METADATA_2011_HSD_RECEPTION_REPORT
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.AvgThroughput
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel
-import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevelEntry
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeReport
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.ReceptionReport
@@ -26,31 +34,51 @@ class QoEMetricsExoPlayer(
         return null
     }
 
+    /**
+     * Returns the buffer level entries that were recorded since the list was reset the last time
+     *
+     * @return {BufferLevel}
+     */
     private fun getBufferLevel(): BufferLevel {
-        val level: Int = exoPlayerAdapter.getBufferLength().toInt()
-        val entries = ArrayList<BufferLevelEntry>()
-        val time: Long = utils.getCurrentTimestamp()
-        val entry = BufferLevelEntry(time, level)
-        entries.add(entry)
-
-        return BufferLevel(entries)
+        return exoPlayerAdapter.getBufferLevel()
     }
 
+    /**
+     * Returns all representation switches that have occurred since the list was reset the last time
+     *
+     * @return {RepresentationSwitchList}
+     */
     private fun getRepresentationSwitchList(): RepresentationSwitchList {
         return exoPlayerAdapter.getRepresentationSwitchList()
     }
 
+    /**
+     * Returns all HTTP requests that were issues since the list was reset the last time
+     *
+     * @return {HttpList}
+     */
     private fun getHttpList(): HttpList {
         return exoPlayerAdapter.getHttpList()
     }
 
-    fun serializeQoEMetricsReportToXml(input: ReceptionReport): String {
+    /**
+     * Converts a ReceptionReport to XML using the Jackson library
+     *
+     * @param {ReceptionReport} input
+     * @return
+     */
+    fun serializeReceptionReportToXml(input: ReceptionReport): String {
         val xmlMapper = XmlMapper()
         val serializedResult = xmlMapper.writeValueAsString(input)
 
         return "<?xml version=\"1.0\"?>$serializedResult"
     }
 
+    /**
+     * Generate a Qoe metrics report and serializes it to XML
+     *
+     * @return {String}
+     */
     fun getQoeMetricsReport(): String {
         val qoeMetricsReport = QoeReport()
 
@@ -76,8 +104,7 @@ class QoEMetricsExoPlayer(
             THREE_GPP_METADATA_2011_HSD_RECEPTION_REPORT.SCHEMA + " " + THREE_GPP_METADATA_2011_HSD_RECEPTION_REPORT.LOCATION
         receptionReport.xsi = THREE_GPP_METADATA_2011_HSD_RECEPTION_REPORT.XSI
 
-        return serializeQoEMetricsReportToXml(receptionReport)
+        return serializeReceptionReportToXml(receptionReport)
     }
-
 
 }

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
@@ -1,0 +1,53 @@
+package com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP
+
+import androidx.media3.common.util.UnstableApi
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.AvgThroughput
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevelEntry
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsReport
+import com.fivegmag.a5gmsmediastreamhandler.ExoPlayerAdapter
+import org.simpleframework.xml.core.Persister
+import java.io.StringWriter
+
+@UnstableApi
+class QoEMetricsExoPlayer(private val exoPlayerAdapter: ExoPlayerAdapter) {
+
+    private fun getAverageThroughput() : AvgThroughput? {
+        return null
+    }
+
+    private fun getBufferLevel(): BufferLevel {
+        val level: Int = exoPlayerAdapter.getBufferLength().toInt()
+        val entries = ArrayList<BufferLevelEntry>()
+        val time: Long = getCurrentTimestamp()
+        val entry = BufferLevelEntry(time, level)
+        entries.add(entry)
+
+        return BufferLevel(entries)
+    }
+
+
+    private fun serializeToXml(qoeMetricsReport: QoeMetricsReport) : String {
+        val serializer = Persister()
+        val stringWriter = StringWriter()
+
+        serializer.write(qoeMetricsReport, stringWriter)
+
+        return stringWriter.toString()
+    }
+
+    fun getQoeMetricsReport() : String {
+        val metricsList = ArrayList<Any>()
+        val bufferLevel = getBufferLevel()
+        metricsList.add(bufferLevel)
+        val qoeMetricsReport = QoeMetricsReport(metricsList)
+
+        return serializeToXml(qoeMetricsReport)
+    }
+
+    private fun getCurrentTimestamp() : Long {
+        return System.currentTimeMillis();
+    }
+
+
+}

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
@@ -1,14 +1,15 @@
 package com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP
 
 import androidx.media3.common.util.UnstableApi
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fivegmag.a5gmscommonlibrary.helpers.Utils
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.AvgThroughput
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevelEntry
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsReport
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import com.fivegmag.a5gmsmediastreamhandler.ExoPlayerAdapter
-import org.simpleframework.xml.core.Persister
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import org.xmlpull.v1.XmlSerializer
@@ -47,14 +48,10 @@ class QoEMetricsExoPlayer(
     }
 
 
-    fun serializeQoEMetricToXml(input: HttpList): String {
-        val serializer = Persister()
-        val stringWriter = StringWriter()
+    fun serializeQoEMetricsReportToXml(input: QoeMetricsReport): String {
+        val xmlMapper = XmlMapper()
 
-        serializer.write(input, stringWriter)
-
-        val metricString = stringWriter.toString()
-        return "<QoeMetric>$metricString</QoeMetric>"
+        return xmlMapper.writeValueAsString(input)
     }
 
     fun cleanupXml(xmlString: String): String {
@@ -116,22 +113,22 @@ class QoEMetricsExoPlayer(
     }
 
     fun getQoeMetricsReport(): String {
-        val metricsList = ArrayList<String>()
+        val qoeMetricsReport = QoeMetricsReport()
         val bufferLevel = getBufferLevel()
         val representationSwitchList = getRepresentationSwitchList()
         val httpList = getHttpList()
 
         if (bufferLevel.entries.size > 0) {
-           // metricsList.add(serializeQoEMetricToXml(bufferLevel))
+            //qoeMetricsReport.entries.add(bufferLevel)
         }
         if (representationSwitchList.entries.size > 0) {
-            //metricsList.add(serializeQoEMetricToXml(representationSwitchList))
+            //qoeMetricsReport.entries.add(representationSwitchList)
         }
         if (httpList.entries.size > 0) {
-            metricsList.add(serializeQoEMetricToXml(httpList))
+            //qoeMetricsReport.entries.add(httpList)
         }
 
-        return java.lang.String.join(" ", metricsList)
+        return serializeQoEMetricsReportToXml(qoeMetricsReport)
     }
 
 

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
@@ -1,15 +1,22 @@
 package com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP
 
+import android.util.Log
 import androidx.media3.common.util.UnstableApi
 import com.fivegmag.a5gmscommonlibrary.helpers.Utils
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.AvgThroughput
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevelEntry
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsReport
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import com.fivegmag.a5gmsmediastreamhandler.ExoPlayerAdapter
 import org.simpleframework.xml.core.Persister
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import org.xmlpull.v1.XmlSerializer
+import java.io.StringReader
 import java.io.StringWriter
+
 
 @UnstableApi
 class QoEMetricsExoPlayer(
@@ -17,6 +24,7 @@ class QoEMetricsExoPlayer(
 ) {
 
     private val utils: Utils = Utils()
+    private val TAG = "QoEMetricsExoPlayer"
 
     private fun getAverageThroughput(): AvgThroughput? {
         return null
@@ -32,8 +40,12 @@ class QoEMetricsExoPlayer(
         return BufferLevel(entries)
     }
 
-    private fun getRepresentationSwitchList() : RepresentationSwitchList {
+    private fun getRepresentationSwitchList(): RepresentationSwitchList {
         return exoPlayerAdapter.getRepresentationSwitchList()
+    }
+
+    private fun getHttpList(): HttpList {
+        return exoPlayerAdapter.getHttpList()
     }
 
 
@@ -43,15 +55,84 @@ class QoEMetricsExoPlayer(
 
         serializer.write(qoeMetricsReport, stringWriter)
 
-        return stringWriter.toString()
+        val serializedData = stringWriter.toString()
+
+        //return serializedData
+        return cleanupXml(serializedData)
+    }
+
+    fun cleanupXml(xmlString: String): String {
+        val factory = XmlPullParserFactory.newInstance()
+        factory.isNamespaceAware = true
+        val xpp = factory.newPullParser()
+        xpp.setInput(StringReader(xmlString))
+
+        val writer = StringWriter()
+        val serializer: XmlSerializer = factory.newSerializer()
+        serializer.setOutput(writer)
+
+        var eventType = xpp.eventType
+
+        while (eventType != XmlPullParser.END_DOCUMENT) {
+            when (eventType) {
+                XmlPullParser.START_TAG -> {
+                    if (xpp.name != "object") {
+                        serializer.startTag(xpp.namespace, xpp.name)
+
+                        // Copy attributes except "class" and those with value -1
+                        for (i in 0 until xpp.attributeCount) {
+                            val attributeName = xpp.getAttributeName(i)
+                            val attributeValue = xpp.getAttributeValue(i)
+                            if (attributeName != "class" && attributeValue != "-1") {
+                                serializer.attribute("", attributeName, attributeValue)
+                            }
+                        }
+
+                    }
+                }
+
+                XmlPullParser.END_TAG -> {
+                    if (xpp.name != "object") {
+                        serializer.endTag(xpp.namespace, xpp.name)
+                    }
+                }
+
+                XmlPullParser.TEXT -> {
+                    if (xpp.name != "object") {
+                        serializer.text(xpp.text)
+                    }
+                }
+            }
+            eventType = xpp.next()
+        }
+
+        val result = writer.toString()
+
+        // Remove empty lines
+        val lines = result.split("\n")
+            .filter { it.trim().isNotEmpty() }
+            .toMutableList()
+
+        // Join the lines back with newlines
+        return lines.joinToString("\n")
     }
 
     fun getQoeMetricsReport(): String {
         val metricsList = ArrayList<Any>()
         val bufferLevel = getBufferLevel()
         val representationSwitchList = getRepresentationSwitchList()
-        metricsList.add(bufferLevel)
-        metricsList.add(representationSwitchList)
+        val httpList = getHttpList()
+
+        if (bufferLevel.entries.size > 0) {
+            metricsList.add(bufferLevel)
+        }
+        if (representationSwitchList.entries.size > 0) {
+            metricsList.add(representationSwitchList)
+        }
+        if (httpList.entries.size > 0) {
+            metricsList.add(httpList)
+        }
+
         val qoeMetricsReport = QoeMetricsReport(metricsList)
 
         return serializeToXml(qoeMetricsReport)

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
@@ -1,33 +1,43 @@
 package com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP
 
 import androidx.media3.common.util.UnstableApi
+import com.fivegmag.a5gmscommonlibrary.helpers.Utils
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.AvgThroughput
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevelEntry
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsReport
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import com.fivegmag.a5gmsmediastreamhandler.ExoPlayerAdapter
 import org.simpleframework.xml.core.Persister
 import java.io.StringWriter
 
 @UnstableApi
-class QoEMetricsExoPlayer(private val exoPlayerAdapter: ExoPlayerAdapter) {
+class QoEMetricsExoPlayer(
+    private val exoPlayerAdapter: ExoPlayerAdapter
+) {
 
-    private fun getAverageThroughput() : AvgThroughput? {
+    private val utils: Utils = Utils()
+
+    private fun getAverageThroughput(): AvgThroughput? {
         return null
     }
 
     private fun getBufferLevel(): BufferLevel {
         val level: Int = exoPlayerAdapter.getBufferLength().toInt()
         val entries = ArrayList<BufferLevelEntry>()
-        val time: Long = getCurrentTimestamp()
+        val time: Long = utils.getCurrentTimestamp()
         val entry = BufferLevelEntry(time, level)
         entries.add(entry)
 
         return BufferLevel(entries)
     }
 
+    private fun getRepresentationSwitchList() : RepresentationSwitchList {
+        return exoPlayerAdapter.getRepresentationSwitchList()
+    }
 
-    private fun serializeToXml(qoeMetricsReport: QoeMetricsReport) : String {
+
+    private fun serializeToXml(qoeMetricsReport: QoeMetricsReport): String {
         val serializer = Persister()
         val stringWriter = StringWriter()
 
@@ -36,17 +46,15 @@ class QoEMetricsExoPlayer(private val exoPlayerAdapter: ExoPlayerAdapter) {
         return stringWriter.toString()
     }
 
-    fun getQoeMetricsReport() : String {
+    fun getQoeMetricsReport(): String {
         val metricsList = ArrayList<Any>()
         val bufferLevel = getBufferLevel()
+        val representationSwitchList = getRepresentationSwitchList()
         metricsList.add(bufferLevel)
+        metricsList.add(representationSwitchList)
         val qoeMetricsReport = QoeMetricsReport(metricsList)
 
         return serializeToXml(qoeMetricsReport)
-    }
-
-    private fun getCurrentTimestamp() : Long {
-        return System.currentTimeMillis();
     }
 
 

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
@@ -17,6 +17,7 @@ import com.fivegmag.a5gmscommonlibrary.helpers.XmlSchemaStrings.THREE_GPP_METADA
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.AvgThroughput
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.MpdInformation
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.PlaybackMetricsRequest
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeReport
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.ReceptionReport
@@ -61,6 +62,10 @@ class QoEMetricsExoPlayer(
      */
     private fun getHttpList(): HttpList {
         return exoPlayerAdapter.getHttpList()
+    }
+
+    private fun getMpdInformation() : ArrayList<MpdInformation> {
+        return exoPlayerAdapter.getMpdInformation()
     }
 
     /**
@@ -129,6 +134,13 @@ class QoEMetricsExoPlayer(
             val httpList = getHttpList()
             if (httpList.entries.size > 0) {
                 qoeMetricsReport.httpList = arrayListOf(httpList)
+            }
+        }
+
+        if (shouldReportMetric(Metrics.MPD_INFORMATION, playbackMetricsRequest.metrics)) {
+            val mpdInformation = getMpdInformation()
+            if (mpdInformation.size > 0) {
+                qoeMetricsReport.mpdInformation = mpdInformation
             }
         }
 

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
@@ -79,8 +79,11 @@ class QoEMetricsExoPlayer(
      *
      * @return {String}
      */
-    fun getQoeMetricsReport(): String {
+    fun getQoeMetricsReport(reportPeriod: Int): String {
         val qoeMetricsReport = QoeReport()
+        qoeMetricsReport.reportTime = utils.getCurrentXsDateTime()
+        qoeMetricsReport.periodId = exoPlayerAdapter.getCurrentPeriodId()
+        qoeMetricsReport.reportPeriod = reportPeriod
 
         val bufferLevel = getBufferLevel()
         if (bufferLevel.entries.size > 0) {
@@ -103,6 +106,7 @@ class QoEMetricsExoPlayer(
         receptionReport.schemaLocation =
             THREE_GPP_METADATA_2011_HSD_RECEPTION_REPORT.SCHEMA + " " + THREE_GPP_METADATA_2011_HSD_RECEPTION_REPORT.LOCATION
         receptionReport.xsi = THREE_GPP_METADATA_2011_HSD_RECEPTION_REPORT.XSI
+        receptionReport.sv = THREE_GPP_METADATA_2011_HSD_RECEPTION_REPORT.SV
 
         return serializeReceptionReportToXml(receptionReport)
     }

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/qoeMetrics/threeGPP/QoEMetricsExoPlayer.kt
@@ -73,7 +73,7 @@ class QoEMetricsExoPlayer(
         val xmlMapper = XmlMapper()
         val serializedResult = xmlMapper.writeValueAsString(input)
 
-        return "<?xml version=\"1.0\"?>$serializedResult"
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>$serializedResult"
     }
 
     /**
@@ -154,6 +154,12 @@ class QoEMetricsExoPlayer(
      * @return
      */
     private fun shouldReportMetric(metric: String, metricsList: ArrayList<String>?): Boolean {
+        // Special handling for HTTP List. Needs to be enabled explicitly as not part of TS 26.247
+        if(metric == Metrics.HTTP_LIST) {
+            if (metricsList != null) {
+                return metricsList.contains(metric)
+            }
+        }
         return metricsList.isNullOrEmpty() || metricsList.contains(metric)
     }
 

--- a/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
+++ b/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
@@ -23,49 +23,48 @@ class QoEMetricsExoPlayerUnitTest {
         val qoeMetricsReport = QoeReport()
         val httpList: HttpList = HttpList(ArrayList<HttpListEntry>())
         val bufferLevel: BufferLevel = BufferLevel(ArrayList<BufferLevelEntry>())
-        val representationSwitchList: RepresentationSwitchList = RepresentationSwitchList(ArrayList<RepresentationSwitch>())
-        val utils : Utils = Utils()
+        val representationSwitchList: RepresentationSwitchList =
+            RepresentationSwitchList(ArrayList<RepresentationSwitch>())
 
-        for(i in 0..2) {
-            val tcpId = i
-            val type = "type"
-            val url = "url"
-            val actualUrl = "actualurl"
-            val range = ""
-            val tRequest = utils.getCurrentTimestamp()
-            val tResponse = utils.getCurrentTimestamp()
-            val responseCode = 200
-            val interval = 100
-            val bytes = 200
-            val trace = Trace(
-                tResponse,
-                100,
-                bytes
-            )
-            val traceList = ArrayList<Trace>()
-            traceList.add(trace)
-            traceList.add(trace)
-            val httpListEntry = HttpListEntry(
-                tcpId,
-                type,
-                url,
-                actualUrl,
-                range,
-                tRequest,
-                tResponse,
-                responseCode,
-                interval,
-                traceList
-            )
+        val tcpId = 1
+        val type = "type"
+        val url = "url"
+        val actualUrl = "actualurl"
+        val range = ""
+        val tRequest = "1970-1-1"
+        val tResponse = "1970-1-2"
+        val responseCode = 200
+        val interval = 100
+        val bytes = 200
+        val trace = Trace(
+            tResponse,
+            100,
+            bytes
+        )
+        val traceList = ArrayList<Trace>()
+        traceList.add(trace)
+        traceList.add(trace)
+        val httpListEntry = HttpListEntry(
+            tcpId,
+            type,
+            url,
+            actualUrl,
+            range,
+            tRequest,
+            tResponse,
+            responseCode,
+            interval,
+            traceList
+        )
 
-            httpList.entries.add(httpListEntry)
+        httpList.entries.add(httpListEntry)
 
-            val representationSwitch = RepresentationSwitch(1,2,"to",3)
-            representationSwitchList.entries.add(representationSwitch)
+        val representationSwitch = RepresentationSwitch("1", "2", "to", 3)
+        representationSwitchList.entries.add(representationSwitch)
 
-            val bufferLevelEntry = BufferLevelEntry(0,1)
-            bufferLevel.entries.add(bufferLevelEntry)
-        }
+        val bufferLevelEntry = BufferLevelEntry("0", 1)
+        bufferLevel.entries.add(bufferLevelEntry)
+
 
         qoeMetricsReport.httpList = ArrayList<HttpList>()
         qoeMetricsReport.httpList!!.add(httpList)
@@ -78,5 +77,8 @@ class QoEMetricsExoPlayerUnitTest {
 
         val receptionReport = ReceptionReport(qoeMetricsReport, "test.mpd", "id")
         val result = qoEMetricsExoPlayer.serializeReceptionReportToXml(receptionReport)
+        val expected =
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?><ReceptionReport contentURI=\"test.mpd\" clientID=\"id\"><QoeReport reportTime=\"\" reportPeriod=\"0\" periodID=\"\"><QoeMetric><HttpList><HttpListEntry tcpid=\"1\" type=\"type\" url=\"url\" actualurl=\"actualurl\" range=\"\" trequest=\"1970-1-1\" tresponse=\"1970-1-2\" responsecode=\"200\" interval=\"100\"><Trace s=\"1970-1-2\" d=\"100\" b=\"200\"/><Trace s=\"1970-1-2\" d=\"100\" b=\"200\"/></HttpListEntry></HttpList></QoeMetric><QoeMetric><RepSwitchList><RepSwitchEvent t=\"1\" mt=\"2\" to=\"to\" lto=\"3\"/></RepSwitchList></QoeMetric><QoeMetric><BufferLevel><BufferLevelEntry t=\"0\" level=\"1\"/></BufferLevel></QoeMetric></QoeReport></ReceptionReport>"
+        assertEquals(expected, result)
     }
 }

--- a/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
+++ b/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
@@ -3,13 +3,13 @@ package com.fivegmag.a5gmsmediastreamhandler
 import com.fivegmag.a5gmscommonlibrary.helpers.Utils
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpListEntry
-import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsReport
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.Trace
 import com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP.QoEMetricsExoPlayer
 import org.junit.Assert.assertEquals
-import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevelEntry
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeReport
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.ReceptionReport
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitch
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import org.junit.Test
@@ -20,7 +20,7 @@ class QoEMetricsExoPlayerUnitTest {
     fun testXmlSerialization() {
         val exoPlayerAdapter = ExoPlayerAdapter()
         val qoEMetricsExoPlayer = QoEMetricsExoPlayer(exoPlayerAdapter)
-        val qoeMetricsReport = QoeMetricsReport()
+        val qoeMetricsReport = QoeReport()
         val httpList: HttpList = HttpList(ArrayList<HttpListEntry>())
         val bufferLevel: BufferLevel = BufferLevel(ArrayList<BufferLevelEntry>())
         val representationSwitchList: RepresentationSwitchList = RepresentationSwitchList(ArrayList<RepresentationSwitch>())
@@ -76,7 +76,8 @@ class QoEMetricsExoPlayerUnitTest {
         qoeMetricsReport.bufferLevel = ArrayList<BufferLevel>()
         qoeMetricsReport.bufferLevel!!.add(bufferLevel)
 
-        val result = qoEMetricsExoPlayer.serializeQoEMetricsReportToXml(qoeMetricsReport)
+        val receptionReport = ReceptionReport(qoeMetricsReport, "test.mpd", "id")
+        val result = qoEMetricsExoPlayer.serializeQoEMetricsReportToXml(receptionReport)
         assertEquals(4, 2 + 2)
     }
 }

--- a/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
+++ b/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
@@ -60,7 +60,7 @@ class QoEMetricsExoPlayerUnitTest {
 
             httpList.entries.add(httpListEntry)
 
-            val representationSwitch = RepresentationSwitch(null,null,"to",null)
+            val representationSwitch = RepresentationSwitch(1,2,"to",3)
             representationSwitchList.entries.add(representationSwitch)
 
             val bufferLevelEntry = BufferLevelEntry(0,1)
@@ -77,7 +77,6 @@ class QoEMetricsExoPlayerUnitTest {
         qoeMetricsReport.bufferLevel!!.add(bufferLevel)
 
         val receptionReport = ReceptionReport(qoeMetricsReport, "test.mpd", "id")
-        val result = qoEMetricsExoPlayer.serializeQoEMetricsReportToXml(receptionReport)
-        assertEquals(4, 2 + 2)
+        val result = qoEMetricsExoPlayer.serializeReceptionReportToXml(receptionReport)
     }
 }

--- a/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
+++ b/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
@@ -1,5 +1,10 @@
 package com.fivegmag.a5gmsmediastreamhandler
 
+import com.fivegmag.a5gmscommonlibrary.helpers.Utils
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpList
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.HttpListEntry
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsReport
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.Trace
 import com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP.QoEMetricsExoPlayer
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -14,5 +19,51 @@ class QoEMetricsExoPlayerUnitTest {
         val targetString = """<QoeReport><QoeMetric><BufferLevel><BufferLevelEntry level="3928" t="1687196339408" /></BufferLevel></QoeMetric><QoeMetric><RepSwitchList><RepSwitchEvent mt="268000" t="1687196338309" to="V300" /><RepSwitchEvent mt="268000" t="1687196338717" to="A48" /></RepSwitchList></QoeMetric></QoeReport>"""
         val result = qoEMetricsExoPlayer.cleanupXml(xmlString)
         assertEquals(targetString, result)
+    }
+    @Test
+    fun serializeToXml() {
+        val exoPlayerAdapter = ExoPlayerAdapter()
+        val qoEMetricsExoPlayer = QoEMetricsExoPlayer(exoPlayerAdapter)
+        val metricsList = ArrayList<Any>()
+        val httpList: HttpList = HttpList(ArrayList<HttpListEntry>())
+        val utils : Utils = Utils()
+
+        for(i in 0..100) {
+            val tcpId = i
+            val type = "type"
+            val url = "url"
+            val actualUrl = "actualurl"
+            val range = ""
+            val tRequest = utils.getCurrentTimestamp()
+            val tResponse = utils.getCurrentTimestamp()
+            val responseCode = 200
+            val interval = 100
+            val bytes = 200
+            val trace = Trace(
+                tResponse,
+                100,
+                bytes
+            )
+            val traceList = ArrayList<Trace>()
+            traceList.add(trace)
+            val httpListEntry = HttpListEntry(
+                tcpId,
+                type,
+                url,
+                actualUrl,
+                range,
+                tRequest,
+                tResponse,
+                responseCode,
+                interval,
+                traceList
+            )
+
+            httpList.entries.add(httpListEntry)
+        }
+
+        val result = qoEMetricsExoPlayer.serializeQoEMetricToXml(httpList)
+
+        assertEquals(4, 2 + 2)
     }
 }

--- a/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
+++ b/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
@@ -1,0 +1,18 @@
+package com.fivegmag.a5gmsmediastreamhandler
+
+import com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP.QoEMetricsExoPlayer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QoEMetricsExoPlayerUnitTest {
+
+    @Test
+    fun cleanupXml() {
+        val exoPlayerAdapter = ExoPlayerAdapter()
+        val qoEMetricsExoPlayer = QoEMetricsExoPlayer(exoPlayerAdapter)
+        val xmlString = """<QoeReport><QoeMetric class="java.util.ArrayList"><object class="com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel"><BufferLevel><BufferLevelEntry level="3928" t="1687196339408"/></BufferLevel></object></QoeMetric><QoeMetric class="java.util.ArrayList"><object class="com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList"><RepSwitchList><RepSwitchEvent lto="-1" mt="268000" t="1687196338309" to="V300"/><RepSwitchEvent lto="-1" mt="268000" t="1687196338717" to="A48"/></RepSwitchList></object></QoeMetric></QoeReport>"""
+        val targetString = """<QoeReport><QoeMetric><BufferLevel><BufferLevelEntry level="3928" t="1687196339408" /></BufferLevel></QoeMetric><QoeMetric><RepSwitchList><RepSwitchEvent mt="268000" t="1687196338309" to="V300" /><RepSwitchEvent mt="268000" t="1687196338717" to="A48" /></RepSwitchList></QoeMetric></QoeReport>"""
+        val result = qoEMetricsExoPlayer.cleanupXml(xmlString)
+        assertEquals(targetString, result)
+    }
+}

--- a/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
+++ b/app/src/test/java/com/fivegmag/a5gmsmediastreamhandler/QoEMetricsExoPlayerUnitTest.kt
@@ -7,28 +7,26 @@ import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.QoeMetricsRepor
 import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.Trace
 import com.fivegmag.a5gmsmediastreamhandler.qoeMetrics.threeGPP.QoEMetricsExoPlayer
 import org.junit.Assert.assertEquals
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevelEntry
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitch
+import com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList
 import org.junit.Test
 
 class QoEMetricsExoPlayerUnitTest {
 
     @Test
-    fun cleanupXml() {
+    fun testXmlSerialization() {
         val exoPlayerAdapter = ExoPlayerAdapter()
         val qoEMetricsExoPlayer = QoEMetricsExoPlayer(exoPlayerAdapter)
-        val xmlString = """<QoeReport><QoeMetric class="java.util.ArrayList"><object class="com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.BufferLevel"><BufferLevel><BufferLevelEntry level="3928" t="1687196339408"/></BufferLevel></object></QoeMetric><QoeMetric class="java.util.ArrayList"><object class="com.fivegmag.a5gmscommonlibrary.qoeMetricsModels.threeGPP.RepresentationSwitchList"><RepSwitchList><RepSwitchEvent lto="-1" mt="268000" t="1687196338309" to="V300"/><RepSwitchEvent lto="-1" mt="268000" t="1687196338717" to="A48"/></RepSwitchList></object></QoeMetric></QoeReport>"""
-        val targetString = """<QoeReport><QoeMetric><BufferLevel><BufferLevelEntry level="3928" t="1687196339408" /></BufferLevel></QoeMetric><QoeMetric><RepSwitchList><RepSwitchEvent mt="268000" t="1687196338309" to="V300" /><RepSwitchEvent mt="268000" t="1687196338717" to="A48" /></RepSwitchList></QoeMetric></QoeReport>"""
-        val result = qoEMetricsExoPlayer.cleanupXml(xmlString)
-        assertEquals(targetString, result)
-    }
-    @Test
-    fun serializeToXml() {
-        val exoPlayerAdapter = ExoPlayerAdapter()
-        val qoEMetricsExoPlayer = QoEMetricsExoPlayer(exoPlayerAdapter)
-        val metricsList = ArrayList<Any>()
+        val qoeMetricsReport = QoeMetricsReport()
         val httpList: HttpList = HttpList(ArrayList<HttpListEntry>())
+        val bufferLevel: BufferLevel = BufferLevel(ArrayList<BufferLevelEntry>())
+        val representationSwitchList: RepresentationSwitchList = RepresentationSwitchList(ArrayList<RepresentationSwitch>())
         val utils : Utils = Utils()
 
-        for(i in 0..100) {
+        for(i in 0..2) {
             val tcpId = i
             val type = "type"
             val url = "url"
@@ -46,6 +44,7 @@ class QoEMetricsExoPlayerUnitTest {
             )
             val traceList = ArrayList<Trace>()
             traceList.add(trace)
+            traceList.add(trace)
             val httpListEntry = HttpListEntry(
                 tcpId,
                 type,
@@ -60,10 +59,24 @@ class QoEMetricsExoPlayerUnitTest {
             )
 
             httpList.entries.add(httpListEntry)
+
+            val representationSwitch = RepresentationSwitch(null,null,"to",null)
+            representationSwitchList.entries.add(representationSwitch)
+
+            val bufferLevelEntry = BufferLevelEntry(0,1)
+            bufferLevel.entries.add(bufferLevelEntry)
         }
 
-        val result = qoEMetricsExoPlayer.serializeQoEMetricToXml(httpList)
+        qoeMetricsReport.httpList = ArrayList<HttpList>()
+        qoeMetricsReport.httpList!!.add(httpList)
 
+        qoeMetricsReport.representationSwitchList = ArrayList<RepresentationSwitchList>()
+        qoeMetricsReport.representationSwitchList!!.add(representationSwitchList)
+
+        qoeMetricsReport.bufferLevel = ArrayList<BufferLevel>()
+        qoeMetricsReport.bufferLevel!!.add(bufferLevel)
+
+        val result = qoEMetricsExoPlayer.serializeQoEMetricsReportToXml(qoeMetricsReport)
         assertEquals(4, 2 + 2)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,5 +2,5 @@
 plugins {
     id 'com.android.application' version '7.3.1' apply false
     id 'com.android.library' version '7.3.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.0' apply false
 }


### PR DESCRIPTION
* Add logic to process metrics reporting scheme capability requests from the Media Session Handler
* Add logic to process metrics reporting messages requests from the Media Session Handler
* Add additional methods to the `ExoPlayerAdapter` to reset metrics in the `ExoPlayerListener` and query information such as the manifest URL
* Add support for deriving `HTTPList`, `RepresentationSwitchList`, `MPDInformation`, and `BufferLevel` metrics according to 26.247