### PR TITLE
Documentation update

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,7 +65,7 @@ below). To include the library from a local Maven repository we need to publish 
 To include the 5GMS Common Library from a local Maven repository apply the following changes.
 
 Note: When using the other 5G-MAG client-side projects the changes below are already included. In
-this case the Media Stream Handler only needs to be published to the local Maven repository (see
+this case the 5GMS Media Stream Handler only needs to be published to the local Maven repository (see
 above).
 
 #### 1. Add `mavenLocal()` to your project gradle file

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ ETSI TS 126.501.
 ### Media Stream Handler (Media Player) for 5GMSd
 A Media Stream Handler (Media Player) enables playback and rendering of a media
 presentation based on a media player entry and exposing some basic controls such as play, pause,
-seek, stop to the 5GMS-Aware Application. It consumes media from the 5GMSd AS at reference point M4d.
+seek, stop to the 5GMSd-Aware Application. It consumes media from the 5GMSd AS at reference point M4d.
 
 
 #### Specifications

--- a/Readme.md
+++ b/Readme.md
@@ -1,25 +1,28 @@
-# 5GMSd Media Stream Handler
+# 5GMS Media Stream Handler
 
-This repository holds the 5GMSd Media Stream Handler implementation of the 5G-MAG Reference Tools.
+This repository holds the 5GMS Media Stream Handler implementation of the 5G-MAG Reference Tools.
+Note that currently this implementation only supports downlink media streaming.
 
 ## Introduction
 
-The 5GMSd Media Stream Handler is a 5GMSd client component that forms part of the 5G Media Services framework as defined in
-ETSI TS 126.501. A Media Stream Handler (Media Player) enables playback and rendering of a media
+The 5GMS Media Stream Handler is a 5GMS client component that forms part of the 5G Media Services framework as defined in
+ETSI TS 126.501.
+
+### Media Stream Handler (Media Player) for 5GMSd
+A Media Stream Handler (Media Player) enables playback and rendering of a media
 presentation based on a media player entry and exposing some basic controls such as play, pause,
-seek, stop to the 5GMSd-Aware Application. It consumes media from the 5GMSd AS at reference point M4d.
+seek, stop to the 5GMS-Aware Application. It consumes media from the 5GMSd AS at reference point M4d.
 
-### About the implementation
 
-The 5GMSd Media Stream Handler is an Android library that includes
-the [ExoPlayer](https://github.com/google/ExoPlayer) as a dependency. The 5GMSd Media Stream Handler
+#### Specifications
+
+A list of specification related to 5G Downlink Media Streaming is available in the [Standards Wiki](https://github.com/5G-MAG/Standards/wiki/5G-Downlink-Media-Streaming-Architecture-(5GMSd):-Relevant-Specifications).
+
+#### About the implementation
+
+The 5GMSd Media Stream Handler is an Android library that includes the [ExoPlayer](https://github.com/google/ExoPlayer) as a dependency. The 5GMSd Media Stream Handler
 implements an adapter around the ExoPlayer APIs to expose TS.26.512 M7d interface functionality.
-Moreover, a `MediaSessionHandlerAdapter` establishes a Messenger connection to the [Media Session
-Handler](https://github.com/5G-MAG/rt-5gms-media-session-handler). The 5GMSd Media Stream Handler is included as an Android library by 5GMSd-Aware Application.
-
-### Specifications
-
-A list of specification related to this repository is available in the [Standards Wiki](https://github.com/5G-MAG/Standards/wiki/5G-Downlink-Media-Streaming-Architecture-(5GMSd):-Relevant-Specifications).
+Moreover, a `MediaSessionHandlerAdapter` establishes a Messenger connection to the [Media Session Handler](https://github.com/5G-MAG/rt-5gms-media-session-handler). The 5GMSd Media Stream Handler is included as an Android library by 5GMSd-Aware Application.
 
 ## Downloading
 
@@ -50,7 +53,7 @@ project by specifying the path to the bundle.
 
 ## Publish to local Maven Repository
 
-The preferred way to include the 5GMSd Media Stream Handler is via a local or remote Maven repository (see
+The preferred way to include the 5GMS Media Stream Handler is via a local or remote Maven repository (see
 below). To include the library from a local Maven repository we need to publish it locally first:
 
 ````
@@ -59,10 +62,10 @@ below). To include the library from a local Maven repository we need to publish 
 
 ## Include from local Maven Repository
 
-To include the 5GMSd Common Library from a local Maven repository apply the following changes.
+To include the 5GMS Common Library from a local Maven repository apply the following changes.
 
 Note: When using the other 5G-MAG client-side projects the changes below are already included. In
-this case the 5GMSd Media Stream Handler only needs to be published to the local Maven repository (see
+this case the Media Stream Handler only needs to be published to the local Maven repository (see
 above).
 
 #### 1. Add `mavenLocal()` to your project gradle file
@@ -75,7 +78,7 @@ dependencyResolutionManagement {
 }
 ````
 
-#### 2. Include the 5GMSd Common Library in your module gradle file
+#### 2. Include the 5GMS Common Library in your module gradle file
 
 ````
 dependencies {


### PR DESCRIPTION
Rationale of the update:

Keep the name of the repo generic (5GMS)
Specify that currently this is only 5GMSd
Introduction and implementation details are tailored to 5GMSd
Download, building, installation, running are kept generic for 5GMS