### PR TITLE
Add required changes to derive basic consumption report

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdk 29
         targetSdk 32
         versionCode 1
-        versionName "1.0.2"
+        versionName "1.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -37,7 +37,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.fivegmag'
             artifactId = 'a5gmsmediastreamhandler'
-            version = '1.0.2'
+            version = '1.1.0'
             afterEvaluate {
                 from components.release
             }
@@ -65,7 +65,9 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.fivegmag:a5gmscommonlibrary:1.0.2'
+    implementation 'com.fivegmag:a5gmscommonlibrary:1.1.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
+    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'

--- a/app/src/androidTest/java/com/fivegmag/a5gmsmediastreamhandler/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/fivegmag/a5gmsmediastreamhandler/ExampleInstrumentedTest.kt
@@ -1,7 +1,12 @@
 package com.fivegmag.a5gmsmediastreamhandler
 
+import android.content.Context
+import android.telephony.CellInfo
+import android.telephony.TelephonyManager
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.fivegmag.a5gmscommonlibrary.models.CellIdentifierType
+import com.fivegmag.a5gmscommonlibrary.models.TypedLocation
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,5 +25,28 @@ class ExampleInstrumentedTest {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         assertEquals("com.fivegmag.a5gmsmediastreamhandler", appContext.packageName)
+    }
+
+    @Test
+    fun getLocations() {
+        val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+        val locations = ArrayList<TypedLocation>()
+        val telephonyManager =
+            context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+        try {
+            val cellInfoList: List<CellInfo> = telephonyManager.allCellInfo
+
+            for (cellInfo in cellInfoList) {
+                if (cellInfo.isRegistered) {
+                    val cellIdentity = cellInfo.cellIdentity
+                    val location = cellIdentity.toString()
+                    locations.add(TypedLocation(CellIdentifierType.CGI, location))
+                }
+            }
+        } catch (e: SecurityException) {
+            assertEquals("com.fivegmag.a5gmsmediastreamhandler", "com.fivegmag.a5gmsmediastreamhandler")
+        }
+
+        assertEquals("com.fivegmag.a5gmsmediastreamhandler", "com.fivegmag.a5gmsmediastreamhandler")
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -71,7 +71,8 @@ class ExoPlayerAdapter() {
         bandwidthMeter = DefaultBandwidthMeter.Builder(context).build()
         playerView = exoPlayerView
         playerView.player = playerInstance
-        playerListener = ExoPlayerListener(mediaSessionHandlerAdapter, playerInstance, playerView)
+        playerListener =
+            ExoPlayerListener(mediaSessionHandlerAdapter, playerInstance, playerView, context)
         playerInstance.addAnalyticsListener(playerListener)
     }
 

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -36,7 +36,7 @@ class ExoPlayerAdapter() {
 
     private lateinit var playerInstance: ExoPlayer
     private lateinit var playerView: PlayerView
-    private lateinit var activeMediaItem: MediaItem
+    private var activeMediaItem: MediaItem? = null
     private lateinit var activeManifestUrl: String
     private lateinit var playerListener: ExoPlayerListener
     private lateinit var bandwidthMeter: DefaultBandwidthMeter
@@ -76,7 +76,12 @@ class ExoPlayerAdapter() {
     }
 
     fun attach(url: String, contentType: String = "") {
-        val mediaItem : MediaItem
+        // Send the final consumption report
+        if (activeMediaItem != null) {
+            mediaSessionHandlerAdapter.sendConsumptionReport()
+        }
+        resetListenerValues()
+        val mediaItem: MediaItem
         when (contentType) {
             ContentTypes.DASH -> {
                 mediaItem = MediaItem.Builder()
@@ -84,12 +89,14 @@ class ExoPlayerAdapter() {
                     .setMimeType(MimeTypes.APPLICATION_MPD)
                     .build()
             }
+
             ContentTypes.HLS -> {
                 mediaItem = MediaItem.Builder()
                     .setUri(url)
                     .setMimeType(MimeTypes.APPLICATION_M3U8)
                     .build()
             }
+
             else -> {
                 mediaItem = MediaItem.fromUri(url)
             }
@@ -100,11 +107,11 @@ class ExoPlayerAdapter() {
         activeManifestUrl = url
     }
 
-    fun getActiveMediaItem(): MediaItem {
-        return activeMediaItem
+    private fun resetListenerValues() {
+        playerListener.reset()
     }
 
-    fun getCurrentManifestUri() : String {
+    fun getCurrentManifestUri(): String {
         return activeManifestUrl
     }
 
@@ -161,8 +168,8 @@ class ExoPlayerAdapter() {
         return playerListener.getConsumptionReportingUnitList()
     }
 
-    fun resetConsumptionReportingListenerValues() {
-        playerListener.resetConsumptionReport()
+    fun cleanConsumptionReportingList() {
+        playerListener.cleanConsumptionReportingList()
     }
 
     fun getStatusInformation(status: String): Any? {

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerAdapter.kt
@@ -23,6 +23,7 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.exoplayer.util.EventLogger
 import androidx.media3.ui.PlayerView
+import com.fivegmag.a5gmscommonlibrary.consumptionReporting.ConsumptionReportingUnit
 import com.fivegmag.a5gmscommonlibrary.helpers.ContentTypes
 import com.fivegmag.a5gmscommonlibrary.helpers.PlayerStates
 import com.fivegmag.a5gmscommonlibrary.helpers.StatusInformation
@@ -36,6 +37,7 @@ class ExoPlayerAdapter() {
     private lateinit var playerInstance: ExoPlayer
     private lateinit var playerView: PlayerView
     private lateinit var activeMediaItem: MediaItem
+    private lateinit var activeManifestUrl: String
     private lateinit var playerListener: ExoPlayerListener
     private lateinit var bandwidthMeter: DefaultBandwidthMeter
     private lateinit var mediaSessionHandlerAdapter: MediaSessionHandlerAdapter
@@ -95,6 +97,15 @@ class ExoPlayerAdapter() {
 
         playerInstance.setMediaItem(mediaItem)
         activeMediaItem = mediaItem
+        activeManifestUrl = url
+    }
+
+    fun getActiveMediaItem(): MediaItem {
+        return activeMediaItem
+    }
+
+    fun getCurrentManifestUri() : String {
+        return activeManifestUrl
     }
 
     fun preload() {
@@ -144,6 +155,14 @@ class ExoPlayerAdapter() {
 
     private fun getLiveLatency(): Long {
         return playerInstance.currentLiveOffset
+    }
+
+    fun getConsumptionReportingUnitList(): ArrayList<ConsumptionReportingUnit> {
+        return playerListener.getConsumptionReportingUnitList()
+    }
+
+    fun resetConsumptionReportingListenerValues() {
+        playerListener.resetConsumptionReport()
     }
 
     fun getStatusInformation(status: String): Any? {

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/consumptionReporting/ConsumptionReportingExoPlayer.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/consumptionReporting/ConsumptionReportingExoPlayer.kt
@@ -4,9 +4,9 @@ import androidx.media3.common.util.UnstableApi
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fivegmag.a5gmscommonlibrary.consumptionReporting.ConsumptionReport
-import com.fivegmag.a5gmscommonlibrary.consumptionReporting.ConsumptionReportRequest
 import com.fivegmag.a5gmscommonlibrary.helpers.Utils
 import com.fivegmag.a5gmsmediastreamhandler.ExoPlayerAdapter
+import java.util.Date
 
 @UnstableApi
 class ConsumptionReportingExoPlayer(
@@ -16,9 +16,22 @@ class ConsumptionReportingExoPlayer(
     private val utils: Utils = Utils()
     private val reportingClientId = utils.generateUUID()
 
-    fun getConsumptionReport(consumptionReportRequest: ConsumptionReportRequest): String {
+    fun getConsumptionReport(): String {
         val mediaPlayerEntry = exoPlayerAdapter.getCurrentManifestUri()
         val consumptionReportingUnits = exoPlayerAdapter.getConsumptionReportingUnitList()
+
+        // We need to add the duration of the consumption reporting units that are not yet finished
+        for (consumptionReportingUnit in consumptionReportingUnits) {
+            if (!consumptionReportingUnit.finished) {
+                val currentTime = utils.formatDateToOpenAPIFormat(Date())
+                consumptionReportingUnit.duration =
+                    utils.calculateTimestampDifferenceInSeconds(
+                        consumptionReportingUnit.startTime,
+                        currentTime
+                    ).toInt()
+            }
+        }
+
         val consumptionReport = ConsumptionReport(
             mediaPlayerEntry,
             reportingClientId,

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/consumptionReporting/ConsumptionReportingExoPlayer.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/consumptionReporting/ConsumptionReportingExoPlayer.kt
@@ -1,0 +1,31 @@
+package com.fivegmag.a5gmsmediastreamhandler.consumptionReporting
+
+import androidx.media3.common.util.UnstableApi
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fivegmag.a5gmscommonlibrary.consumptionReporting.ConsumptionReport
+import com.fivegmag.a5gmscommonlibrary.consumptionReporting.ConsumptionReportRequest
+import com.fivegmag.a5gmscommonlibrary.helpers.Utils
+import com.fivegmag.a5gmsmediastreamhandler.ExoPlayerAdapter
+
+@UnstableApi
+class ConsumptionReportingExoPlayer(
+    private val exoPlayerAdapter: ExoPlayerAdapter
+) {
+    private val TAG = "ConsumptionReportingExoPlayer"
+    private val utils: Utils = Utils()
+    private val reportingClientId = utils.generateUUID()
+
+    fun getConsumptionReport(consumptionReportRequest: ConsumptionReportRequest): String {
+        val mediaPlayerEntry = exoPlayerAdapter.getCurrentManifestUri()
+        val consumptionReportingUnits = exoPlayerAdapter.getConsumptionReportingUnitList()
+        val consumptionReport = ConsumptionReport(
+            mediaPlayerEntry,
+            reportingClientId,
+            consumptionReportingUnits
+        )
+        val objectMapper: ObjectMapper = jacksonObjectMapper()
+
+        return objectMapper.writeValueAsString(consumptionReport)
+    }
+}


### PR DESCRIPTION
* Increase version number to 1.1.0
* Add basic function to derive `TypedLocation` for ConsumptionReport
* Add a new ConsumptionReportingUnit once the downstream format changed. 
* Send ConsumptionReport to the MediaSessionHandler once requested. There are still missing fields and open issues that will be documented separately in the respective repositories. An example for a consumption report as generated now:

````json
{
  "mediaPlayerEntry": "https://dash.akamaized.net/envivio/EnvivioDash3/manifest.mpd",
  "reportingClientId": "ab960db0-9282-4626-8d45-188c51db0fad",
  "consumptionReportingUnits": [
    {
      "mediaConsumed": "v4_258",
      "mediaEndpointAddress": {
        "domainName": null,
        "ipv4Addr": "192.168.2.4",
        "ipv6Addr": null,
        "portNumber": 80
      },
      "startTime": "2023-10-24T13:55:26Z",
      "duration": 180,
      "locations": [],
      "mimeType": "audio/mp4",
      "finished": false
    },
    {
      "mediaConsumed": "v7_257",
      "mediaEndpointAddress": {
        "domainName": null,
        "ipv4Addr": "192.168.2.4",
        "ipv6Addr": null,
        "portNumber": 80
      },
      "startTime": "2023-10-24T13:55:26Z",
      "duration": 180,
      "locations": [],
      "mimeType": "video/mp4",
      "finished": false
    }
  ]
}
````