### PR TITLE
Add support for consumption reporting fields clientEndpointAddress and serverEndpointAddress as defined in TS 26512 17.7.0

### DIFF
--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/ExoPlayerListener.kt
@@ -17,10 +17,11 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.source.LoadEventInfo
 import androidx.media3.exoplayer.source.MediaLoadData
 import androidx.media3.ui.PlayerView
-import com.fivegmag.a5gmscommonlibrary.consumptionReporting.ConsumptionReportingUnit
 import com.fivegmag.a5gmscommonlibrary.eventbus.DownstreamFormatChangedEvent
+import com.fivegmag.a5gmscommonlibrary.eventbus.LoadStartedEvent
 import com.fivegmag.a5gmscommonlibrary.eventbus.PlaybackStateChangedEvent
 import com.fivegmag.a5gmscommonlibrary.helpers.PlayerStates
 import com.fivegmag.a5gmsmediastreamhandler.helpers.mapStateToConstant
@@ -36,8 +37,6 @@ class ExoPlayerListener(
     private val playerView: PlayerView,
 ) :
     AnalyticsListener {
-
-
 
     override fun onPlaybackStateChanged(
         eventTime: AnalyticsListener.EventTime,
@@ -67,6 +66,14 @@ class ExoPlayerListener(
         mediaLoadData: MediaLoadData
     ) {
         EventBus.getDefault().post(DownstreamFormatChangedEvent(eventTime, mediaLoadData))
+    }
+
+    override fun onLoadStarted(
+        eventTime: AnalyticsListener.EventTime,
+        loadEventInfo: LoadEventInfo,
+        mediaLoadData: MediaLoadData
+    ) {
+        EventBus.getDefault().post(LoadStartedEvent(eventTime, loadEventInfo, mediaLoadData))
     }
 
     override fun onPlayerError(eventTime: AnalyticsListener.EventTime, error: PlaybackException) {

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/consumptionReporting/ConsumptionReportingController.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/consumptionReporting/ConsumptionReportingController.kt
@@ -211,7 +211,6 @@ class ConsumptionReportingController(
     @SuppressLint("Range")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onLoadStartedEvent(event: LoadStartedEvent) {
-        Log.d(TAG, "onLoadStartedEvent")
         try {
             val mimeType = event.mediaLoadData.trackFormat!!.containerMimeType
             if (mimeType != null) {

--- a/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/consumptionReporting/ConsumptionReportingController.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediastreamhandler/consumptionReporting/ConsumptionReportingController.kt
@@ -216,18 +216,9 @@ class ConsumptionReportingController(
             val mimeType = event.mediaLoadData.trackFormat!!.containerMimeType
             if (mimeType != null) {
                 val requestUrl = event.loadEventInfo.dataSpec.uri.toString()
-                val domainName = utils.getDomainName(requestUrl)
-
-                // If the domain name did not change no need to update anything
-                val currentEndpointAddress = serverEndpointAddressesPerMediaType[mimeType]
-                if (currentEndpointAddress != null && currentEndpointAddress.domainName == domainName) {
-                    return
-                }
-
-                utils.getEndpointAddressByRequestUrl(requestUrl) { endpointAddress ->
-                    if (endpointAddress != null) {
-                        serverEndpointAddressesPerMediaType[mimeType] = endpointAddress
-                    }
+                val endpointAddress = utils.getEndpointAddressByRequestUrl(requestUrl)
+                if (endpointAddress != null) {
+                    serverEndpointAddressesPerMediaType[mimeType] = endpointAddress
                 }
             }
         } catch (e: Exception) {


### PR DESCRIPTION
Addresses issue #65 

An example report as created with these changes:

````json
{
  "mediaPlayerEntry": "https://dash.akamaized.net/envivio/EnvivioDash3/manifest.mpd",
  "reportingClientId": "64cfef91-1abb-4a2a-ae9f-8bfc6de098f7",
  "consumptionReportingUnits": [
    {
      "mediaConsumed": "v7_257",
      "clientEndpointAddress": {
        "ipv4Addr": "192.168.2.4",
        "portNumber": 443
      },
      "serverEndpointAddress": {
        "domainName": "dash.akamaized.net",
        "ipv4Addr": "2.16.238.144",
        "portNumber": 443
      },
      "startTime": "2024-01-17T13:55:13Z",
      "duration": 9,
      "locations": []
    },
    {
      "mediaConsumed": "v4_258",
      "clientEndpointAddress": {
        "ipv4Addr": "192.168.2.4",
        "portNumber": 443
      },
      "serverEndpointAddress": {
        "domainName": "dash.akamaized.net",
        "ipv4Addr": "2.16.238.144",
        "portNumber": 443
      },
      "startTime": "2024-01-17T13:55:13Z",
      "duration": 9,
      "locations": []
    }
  ]
}
````